### PR TITLE
Fix to doctest for bad email address. Removes failure on Py2.7.3

### DIFF
--- a/src/pyramid_simpleauth/schema.py
+++ b/src/pyramid_simpleauth/schema.py
@@ -86,7 +86,7 @@ class Email(validators.Email):
           >>> Email.to_python('foo@baz')
           Traceback (most recent call last):
           ...
-          Invalid: The domain of the email address does not exist (the portion after the @: b.com)
+          Invalid: The domain portion of the email address is invalid (the portion after the @: baz)
 
       Note that when used with ``resolve_domain=True`` it must be a real
       domain::


### PR DESCRIPTION
Doctest is failing with email invalidation message. Guessing this is OK to fix for Ubuntu 12 default version of Python (2.7.3).
