### PR TITLE
Attempt at Py3 compatibility

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -52,7 +52,6 @@ setup(
         'mock',
         'paste',
         'webtest',
-        'pyDNS',
         'dnspython',
     ]
 )

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
+import sys
 from setuptools import setup, find_packages
 
 def _read(file_name):
@@ -9,6 +10,10 @@ def _read(file_name):
     sock.close()
     return text
 
+if sys.version_info[0] == 2:
+    dnspython = "dnspython"
+elif sys.version_info[0] == 3:
+    dnspython = "dnspython3"
 
 setup(
     name='pyramid_simpleauth',
@@ -52,6 +57,6 @@ setup(
         'mock',
         'paste',
         'webtest',
-        'dnspython',
+        dnspython,
     ]
 )

--- a/src/pyramid_simpleauth/policy.py
+++ b/src/pyramid_simpleauth/policy.py
@@ -17,7 +17,10 @@ __all__ = [
 import logging
 logger = logging.getLogger(__name__)
 
-import urlparse
+try:
+    from urllib.parse import urlparse
+except ImportError:
+    from urlparse import urlparse
 import re
 
 import zope.interface as zi

--- a/src/pyramid_simpleauth/schema.py
+++ b/src/pyramid_simpleauth/schema.py
@@ -3,7 +3,10 @@
 """Provides FormEncode based validators and schemas."""
 
 import re
-from urlparse import urlparse
+try:
+    from urllib.parse import urlparse
+except ImportError:
+    from urlparse import urlparse
 
 from formencode import validators, Schema
 from formencode import Invalid


### PR DESCRIPTION
This includes several changes:
 * Remove unused PyDNS dependency.
 * Change dependency on dnspython to one of dnspython and dnspython3.
 * Change urlparse to a py2/py3 hacky works-in-both version.
 * Change to zope.interface.implementer.

However, at least one dependency (pyramid_simpleform) is 5 years out of date on PyPi, so it doesn't support Py3. Though it appears fine in the current master on github.

pyramid_basemodel generate_random_digest also needs a small change for py3 support. so does pyramid_simpleauth\model.py . (Both should use bytes, not unicode.)

passlib has supported python3 for some time now, I doubt that will cause issues.

I'm going to stop here, but for the next person who attempts this they'll have less work to do.