### PR TITLE
docs: Fix a few typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ There are many other auth implementations for Pyramid, including [apex][] and
 following the excellent [pyramid_auth_demo][].  This package aims to be:
 
 * relatively simple: with a limited feature set
-* extensible: with event hooks and overrideable templates
+* extensible: with event hooks and overridable templates
 * performant: minimising db queries
 
 # Features

--- a/src/pyramid_simpleauth/model.py
+++ b/src/pyramid_simpleauth/model.py
@@ -521,7 +521,7 @@ class BearerToken(Base, BaseMixin):
     # Has the token been revoked?
     has_been_revoked = Column(Boolean, default=False, nullable=False)
 
-    # Optional: space seperated list of acceptable scopes.
+    # Optional: space separated list of acceptable scopes.
     scope = Column(Unicode(256))
 
     # List of scopes.

--- a/src/pyramid_simpleauth/tests.py
+++ b/src/pyramid_simpleauth/tests.py
@@ -201,7 +201,7 @@ class TestSignup(BaseTestCase):
         }
         res = self.app.post('/auth/signup', post_data, status=302)
         assert res  # to satisfy pyflakes
-        # Handler was called with the authentiated user as the second arg.
+        # Handler was called with the authenticated user as the second arg.
         self.assertTrue(mock_subscriber.called)
         event = mock_subscriber.call_args_list[0][0][0]
         self.assertTrue(isinstance(event.user, User))
@@ -299,7 +299,7 @@ class TestLogin(BaseTestCase):
         }
         res = self.app.post('/auth/login', post_data, status=302)
         assert res  # to satisfy pyflakes
-        # Handler was called with the authentiated user as the second arg.
+        # Handler was called with the authenticated user as the second arg.
         self.assertTrue(mock_subscriber.called)
         event = mock_subscriber.call_args_list[0][0][0]
         self.assertTrue(isinstance(event.user, User))
@@ -366,7 +366,7 @@ class TestAuthenticate(BaseTestCase):
         headers = {'X-Requested-With': 'XMLHttpRequest'}
         res = self.app.post('/auth/authenticate', post_data, headers=headers)
         assert res  # to satisfy pyflakes
-        # Handler was called with the authentiated user as the second arg.
+        # Handler was called with the authenticated user as the second arg.
         self.assertTrue(mock_subscriber.called)
         event = mock_subscriber.call_args_list[0][0][0]
         self.assertTrue(isinstance(event.user, User))
@@ -434,7 +434,7 @@ class TestLogout(BaseTestCase):
         # Logout.
         res = self.app.post('/auth/logout', status=302)
         assert res  # to satisfy pyflakes
-        # Handler was called with the authentiated user as the second arg.
+        # Handler was called with the authenticated user as the second arg.
         self.assertTrue(mock_subscriber.called)
         event = mock_subscriber.call_args_list[0][0][0]
         self.assertTrue(isinstance(event.user, User))
@@ -460,7 +460,7 @@ class TestLogout(BaseTestCase):
 class TestChangePassword(BaseTestCase):
 
     def test_wrong_old_password(self):
-        "No password change if old password is not corret"
+        "No password change if old password is not correct"
 
         # Create a user.
         user = self.makeUser('thruflo', 'Password')
@@ -586,7 +586,7 @@ class TestChangePassword(BaseTestCase):
         # Verify logged out.
         self.assertTrue(len(res.headers['Set-Cookie']) < 200)
 
-        # Handler was called with the authentiated user as the second arg.
+        # Handler was called with the authenticated user as the second arg.
         self.assertTrue(mock_subscriber.called)
         event = mock_subscriber.call_args_list[0][0][0]
         self.assertTrue(isinstance(event.user, User))
@@ -744,7 +744,7 @@ class TestPreferEmail(BaseTestCase):
             'email_address': email.address + 'not an email address'
         })
 
-        # Email address should not be prefered
+        # Email address should not be preferred
         self.assertNotEquals(user.preferred_email, email)
 
     def test_prefer_non_persisted_email(self):

--- a/src/pyramid_simpleauth/view.py
+++ b/src/pyramid_simpleauth/view.py
@@ -136,7 +136,7 @@ def forbidden_view(request):
           >>> mock_request.path = '/forbidden/page'
           >>> mock_request.route_url.return_value = 'http://foo.com/login'
 
-      If the user is already logged in, it means they don't have the requisit
+      If the user is already logged in, it means they don't have the requisite
       permission, so we raise a 403 Forbidden error::
 
           >>> view.unauthenticated_userid.return_value = 1234


### PR DESCRIPTION
There are small typos in:
- README.md
- src/pyramid_simpleauth/model.py
- src/pyramid_simpleauth/tests.py
- src/pyramid_simpleauth/view.py

Fixes:
- Should read `authenticated` rather than `authentiated`.
- Should read `separated` rather than `seperated`.
- Should read `requisite` rather than `requisit`.
- Should read `preferred` rather than `prefered`.
- Should read `overridable` rather than `overrideable`.
- Should read `correct` rather than `corret`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md